### PR TITLE
デバッグ・実行に支障が出るため.envのPYTHONPATHをコメントアウト

### DIFF
--- a/vscode/templates/.env.template
+++ b/vscode/templates/.env.template
@@ -1,1 +1,1 @@
-PYTHONPATH=/workspace/${source_root}:$$PYTHONPATH
+# PYTHONPATH=/workspace/${source_root}:$$PYTHONPATH


### PR DESCRIPTION
Exastroで環境変数 `PYTHONPATH` を変更すると以下の支障があることが判明
- デバッグ時にbreakpointの適用が上手くいかない
- コード中で `PYTHONPATH` を使っているコードが(Pythonの仕様である)複数パスを前提としていない

そのため `.env.template` の `PYTHONPATH` をコメントアウトした
エディターでimportを追いたい場合は `/workspace/.vscode/.env` から `PYTHONPATH` のコメントアウトを解除する