### PR TITLE
自動フォーマット時の警告対策でflake8のW503を無視する

### DIFF
--- a/vscode/templates/settings.json.template
+++ b/vscode/templates/settings.json.template
@@ -32,7 +32,7 @@
     "python.defaultInterpreterPath": "/usr/bin/python3",
     "python.envFile": "${workspaceFolder}/.vscode/.env",
     "flake8.args": [
-        "--ignore=W293, W504",
+        "--ignore=W293, W503, W504",
         "--max-line-length=250",
         "--max-complexity=20"
     ],
@@ -64,7 +64,7 @@
         "--aggressive", "--aggressive",
     ],
     "python.linting.flake8Args": [
-        "--ignore=W293, W504",
+        "--ignore=W293, W503, W504",
         "--max-line-length=150",
         "--max-complexity=20"
     ],


### PR DESCRIPTION
Fix #5 